### PR TITLE
Improve XML output & Format

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,46 @@
+
+#########################
+# Flake8 Configuration  #
+# (.flake8)             #
+#########################
+[flake8]
+ignore =
+    # pickle
+    S301
+    S403
+    S404
+    S603
+    # Line break before binary operator (flake8 is wrong)
+    W503
+    # Ignore the spaces black puts before columns.
+    E203
+    # allow path extensions for testing.
+    E402
+    DAR101
+    DAR201
+    # flake and pylance disagree on linebreaks in strings.
+    N400
+    # asserts are ok in test.
+    S101
+    C901
+extend-select = B950
+extend-ignore = E501,E701,E704
+exclude =
+    .tox,
+    .git,
+    __pycache__,
+    docs/conf.py,
+    build,
+    dist,
+    *.pyc,
+    *.bib,
+    *.egg-info,
+    .cache,
+    .eggs,
+    data.
+    src/bonn-mensa/__init__.py
+max-line-length = 80
+max-complexity = 20
+import-order-style = pycharm
+application-import-names =
+    bonn_mensa

--- a/src/bonn_mensa/__init__.py
+++ b/src/bonn_mensa/__init__.py
@@ -1,1 +1,3 @@
+"""Meal plans for university canteens in Bonn."""
+
 # empty file for package

--- a/src/bonn_mensa/mensa.py
+++ b/src/bonn_mensa/mensa.py
@@ -1,9 +1,10 @@
+"""Query meal plans for university canteens in Bonn."""
+
 import argparse
 import datetime
 import sys
 import time
 import xml.etree.ElementTree as ET
-from ast import parse
 from html.parser import HTMLParser
 from typing import Dict, List, Optional, Set
 
@@ -12,7 +13,8 @@ import requests
 from colorama import Fore, Style
 from colorama import init as colorama_init
 
-# simulates relative imports for the case where this script is run directly from the command line
+# simulates relative imports for the case where this script
+# is run directly from the command line
 # -> behaves as if it was run as `python -m bonn_mensa.mensa`
 # -> always behaves if it was installed as a package
 if __package__ is None and not hasattr(sys, "frozen"):
@@ -288,7 +290,7 @@ class SimpleMensaResponseParser(HTMLParser):
         else:
             raise NotImplementedError(f"{self.last_nonignored_tag} with data {data}")
 
-    def to_xml(self, wCanteen: str) -> ET.Element:
+    def to_xml(self, canteen: str) -> ET.Element:
         # Define namespaces
         ns = {
             "": "http://openmensa.org/open-mensa-v2",
@@ -305,7 +307,10 @@ class SimpleMensaResponseParser(HTMLParser):
                 "version": "2.1",
                 "xmlns": ns[""],
                 "xmlns:xsi": ns["xsi"],
-                "xsi:schemaLocation": "http://openmensa.org/open-mensa-v2 http://openmensa.org/open-mensa-v2.xsd",
+                "xsi:schemaLocation": (
+                    "http://openmensa.org/open-mensa-v2 "
+                    "http://openmensa.org/open-mensa-v2.xsd"
+                ),
             },
         )
         # Add version element
@@ -385,7 +390,8 @@ def query_mensa(
     xml_indent: bool = False,
 ) -> None:
     if date is None:
-        # If no date is provided get next valid day i.E. working days from monday to fridy
+        # If no date is provided get next valid day
+        #   i.e. working days from monday to friday
         # this does not take into account closures due to operational reasons
         date = get_mensa_data().strftime("%Y-%m-%d")
 
@@ -413,12 +419,15 @@ def query_mensa(
         print(f"### Mensa {canteen} – {date}{filter_str} [{language}]\n")
     elif not xml_output:
         print(
-            f"{QUERY_COLOR}Mensa {canteen} – {date}{filter_str} [{language}]{RESET_COLOR}"
+            f"{QUERY_COLOR}"
+            f"Mensa {canteen} – {date}{filter_str} [{language}]"
+            f"{RESET_COLOR}"
         )
 
     if verbose:
         print(
-            f"Querying for {date=}, {canteen=}, {filtered_categories=}, {filter_mode=}, {url=}"
+            f"Querying for {date=}, {canteen=}, "
+            f"{filtered_categories=}, {filter_mode=}, {url=}"
         )
     r = requests.post(
         url,
@@ -434,7 +443,10 @@ def query_mensa(
 
     if not parser.categories:
         print(
-            f"{WARN_COLOR}Query failed. Please check https://www.studierendenwerk-bonn.de if the mensa is open today.{RESET_COLOR}"
+            f"{WARN_COLOR}"
+            "Query failed. Please check https://www.studierendenwerk-bonn.de"
+            f" if the mensa is open today."
+            f"{RESET_COLOR}"
         )
         return
 
@@ -474,7 +486,7 @@ def query_mensa(
         if show_additives:
             print(f"| {output_strs['MD_TABLE_COL_ADDITIVES'][language]}", end="")
         print("|")
-        print(f"| :-- | :-- | --: | :-- | ", end="")
+        print("| :-- | :-- | --: | :-- | ", end="")
         if show_additives:
             print(":-- |")
         else:
@@ -497,7 +509,7 @@ def query_mensa(
         if markdown_output:
             for meal_idx, meal in enumerate(filtered_meals):
                 if meal_idx:
-                    print(f"| |", end="")
+                    print("| |", end="")
                 else:
                     print(f"| {cat.title} |", end="")
                 if price == "Student":
@@ -544,17 +556,20 @@ def query_mensa(
                     print(" " * (maxlen_catname + 1), end="")
                 if price == "Student":
                     print(
-                        f"{MEAL_COLOR}{meal.title} {PRICE_COLOR}({_fmt_price(meal.student_price)})",
+                        f"{MEAL_COLOR}"
+                        f"{meal.title} {PRICE_COLOR}({_fmt_price(meal.student_price)})",
                         end="",
                     )
                 if price == "Staff":
                     print(
-                        f"{MEAL_COLOR}{meal.title} {PRICE_COLOR}({_fmt_price(meal.staff_price)})",
+                        f"{MEAL_COLOR}"
+                        f"{meal.title} {PRICE_COLOR}({_fmt_price(meal.staff_price)})",
                         end="",
                     )
                 if price == "Guest":
                     print(
-                        f"{MEAL_COLOR}{meal.title} {PRICE_COLOR}({_fmt_price(meal.guest_price)})",
+                        f"{MEAL_COLOR}"
+                        f"{meal.title} {PRICE_COLOR}({_fmt_price(meal.guest_price)})",
                         end="",
                     )
                 if meal.allergens and (
@@ -576,6 +591,7 @@ def query_mensa(
 
 
 def get_parser() -> argparse.ArgumentParser:
+    """Construct an argument parser."""
     parser = argparse.ArgumentParser("mensa")
     filter_group = parser.add_mutually_exclusive_group()
     filter_group.add_argument(
@@ -622,7 +638,8 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--show-all-allergens",
         action="store_true",
-        help="Show all allergens. By default, only allergens relevant to vegans (e.g. milk or fish) are shown.",
+        help="Show all allergens. "
+        "By default, only allergens relevant to vegans (e.g. milk or fish) are shown.",
     )
 
     parser.add_argument(
@@ -652,14 +669,16 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--version",
         action="version",
-        version=f"bonn-mensa v{bonn_mensa.version.__version__} (https://github.com/alexanderwallau/bonn-mensa)",
+        version=f"bonn-mensa v{bonn_mensa.version.__version__} "
+        "(https://github.com/alexanderwallau/bonn-mensa)",
     )
 
     parser.add_argument(
         "--xml",
         action="store_true",
-        help="""Save canteen pan with all allergens as xml. If no filename is given the resulting
-            xml will be saved as <canteen name>_<time>.""",
+        help="Save canteen pan with all allergens as xml. "
+        "If no filename is given the resulting "
+        "xml will be saved as <canteen name>_<time>.",
     )
     parser.add_argument(
         "--glutenfree",
@@ -675,6 +694,7 @@ def get_parser() -> argparse.ArgumentParser:
 
 
 def run_cmd(args: argparse.Namespace) -> None:
+    """Run the meal plan query."""
     if args.vegan:
         filter_mode: Optional[str] = "vegan"
     elif args.vegetarian:
@@ -701,6 +721,7 @@ def run_cmd(args: argparse.Namespace) -> None:
 
 
 def main() -> None:
+    """Program entry point."""
     colorama_init()
     args = get_parser().parse_args()
     run_cmd(args)

--- a/src/bonn_mensa/mensa.py
+++ b/src/bonn_mensa/mensa.py
@@ -375,6 +375,7 @@ def query_mensa(
     colors: bool = True,
     markdown_output: bool = False,
     xml_output: bool = False,
+    xml_indent: bool = False,
 ) -> None:
     if date is None:
         # If no date is provided get next valid day i.E. working days from monday to fridy
@@ -509,6 +510,10 @@ def query_mensa(
         elif xml_output:
             xml_root = parser.to_xml(canteen)
             xml_tree = ET.ElementTree(xml_root)
+
+            if xml_indent:
+                ET.indent(xml_tree)
+
             cat_title = cat.title.replace("& ", "").replace(" ", "-")
 
             filename = f"{canteen}_{cat_title}_{date}_{time.time()}.xml"
@@ -648,6 +653,11 @@ def get_parser():
         action="store_true",
         help="Only show gluten free options",
     )
+    parser.add_argument(
+        "--indent-xml",
+        action="store_true",
+        help="Indent the generated XML files for better readability."
+    )
     return parser
 
 
@@ -673,6 +683,7 @@ def run_cmd(args):
         verbose=args.verbose,
         price=args.price,
         xml_output=args.xml,
+        xml_indent=args.indent_xml,
     )
 
 

--- a/src/bonn_mensa/mensa.py
+++ b/src/bonn_mensa/mensa.py
@@ -403,7 +403,7 @@ def query_mensa(
     filter_str = f" [{filter_mode}]" if filter_mode else ""
     if markdown_output:
         print(f"### Mensa {canteen} – {date}{filter_str} [{language}]\n")
-    else:
+    elif not xml_output:
         print(
             f"{QUERY_COLOR}Mensa {canteen} – {date}{filter_str} [{language}]{RESET_COLOR}"
         )
@@ -429,7 +429,6 @@ def query_mensa(
             f"{WARN_COLOR}Query failed. Please check https://www.studierendenwerk-bonn.de if the mensa is open today.{RESET_COLOR}"
         )
         return
-    print()
 
     queried_categories = [
         cat for cat in parser.categories if cat.title not in filtered_categories
@@ -507,6 +506,16 @@ def query_mensa(
                     print(f" {additives_str} |", end="")
 
                 print("")
+        elif xml_output:
+            xml_root = parser.to_xml(canteen)
+            xml_tree = ET.ElementTree(xml_root)
+            cat_title = cat.title.replace("& ", "").replace(" ", "-")
+
+            filename = f"{canteen}_{cat_title}_{date}_{time.time()}.xml"
+            xml_tree.write(
+                filename, encoding="utf-8", xml_declaration=True, method="xml"
+            )
+            print(f"XML saved to {filename}")
         else:
             cat_str = cat.title.ljust(maxlen_catname + 1)
             print(f"{CATEGORY_COLOR}{cat_str}{RESET_COLOR}", end="")
@@ -546,16 +555,6 @@ def query_mensa(
                     print(f" {ADDITIVE_COLOR}[{additives_str}]", end="")
 
                 print(f"{RESET_COLOR}")
-        if xml_output:
-            xml_root = parser.to_xml(canteen)
-            xml_tree = ET.ElementTree(xml_root)
-            cat_title = cat.title.replace("& ", "").replace(" ", "-")
-
-            filename = f"{canteen}_{cat_title}_{date}_{time.time()}.xml"
-            xml_tree.write(
-                filename, encoding="utf-8", xml_declaration=True, method="xml"
-            )
-            print(f"XML saved to {filename}")
 
 
 def get_parser():

--- a/src/bonn_mensa/mensa.py
+++ b/src/bonn_mensa/mensa.py
@@ -356,8 +356,7 @@ class SimpleMensaResponseParser(HTMLParser):
         self.start_new_category()
 
 
-def get_mensa_data() -> datetime.date:
-    print("Fetching mensa data...")
+def get_mensa_date() -> datetime.date:
     # Since the canteenes ar elocated in NRW get the public holidays for NRW
     nrw_holidays = holidays.country_holidays("DE", subdiv="NW")
 
@@ -393,7 +392,7 @@ def query_mensa(
         # If no date is provided get next valid day
         #   i.e. working days from monday to friday
         # this does not take into account closures due to operational reasons
-        date = get_mensa_data().strftime("%Y-%m-%d")
+        date = get_mensa_date().strftime("%Y-%m-%d")
 
     if colors:
         QUERY_COLOR = Fore.MAGENTA
@@ -678,7 +677,7 @@ def get_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Save canteen pan with all allergens as xml. "
         "If no filename is given the resulting "
-        "xml will be saved as <canteen name>_<time>.",
+        "xml will be saved as <canteen name>_<category>_<time>.",
     )
     parser.add_argument(
         "--glutenfree",

--- a/src/bonn_mensa/mensa.py
+++ b/src/bonn_mensa/mensa.py
@@ -549,7 +549,9 @@ def query_mensa(
         if xml_output:
             xml_root = parser.to_xml(canteen)
             xml_tree = ET.ElementTree(xml_root)
-            filename = f"{canteen}_{date}_{time.time()}.xml"
+            cat_title = cat.title.replace("& ", "").replace(" ", "-")
+
+            filename = f"{canteen}_{cat_title}_{date}_{time.time()}.xml"
             xml_tree.write(
                 filename, encoding="utf-8", xml_declaration=True, method="xml"
             )

--- a/src/bonn_mensa/mensa.py
+++ b/src/bonn_mensa/mensa.py
@@ -159,6 +159,9 @@ class Meal:
     def add_additive(self, additive: str) -> None:
         self.additives.append(additive)
 
+    def __repr__(self) -> str:
+        return f"Meal('{self.title}')"
+
 
 class Category:
     def __init__(self, title: str) -> None:
@@ -167,6 +170,9 @@ class Category:
 
     def add_meal(self, meal: Meal) -> None:
         self.meals.append(meal)
+
+    def __repr__(self) -> str:
+        return f"({self.title}: {self.meals})"
 
 
 class SimpleMensaResponseParser(HTMLParser):

--- a/src/bonn_mensa/version.py
+++ b/src/bonn_mensa/version.py
@@ -1,1 +1,3 @@
+"""bonn-mensa version information."""
+
 __version__ = "1.0.0"


### PR DESCRIPTION
This does twofold (my bad):
1. Minor changes to the XML functionality (running silent, changing filename, allow indentation etc)
2. Formatting the code. I ran `black` and `isort` to format, added type hints s.t. `mypy --strict` passes and addressed most of the remarks raised by `flake8` (although not all)

[WIP as I am currently tweaking]